### PR TITLE
Build background service worker alongside content script

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,8 +16,7 @@
         "https://wafid.com/*"
       ],
       "js": [
-        "content.js",
-        "background.js"
+        "content.js"
       ],
       "css": [
         "assets/styles.css"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -7,16 +8,16 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
-    lib: {
-      entry: "src/main.tsx",
-      name: "WafidCenterContent",
-      formats: ["iife"],
-      fileName: () => "content.js"
-    },
     rollupOptions: {
-      external: [],
+      input: {
+        content: resolve(__dirname, "src/main.tsx"),
+        background: resolve(__dirname, "src/background.ts")
+      },
       output: {
-        assetFileNames: "assets/[name][extname]"
+        entryFileNames: ({ name }) =>
+          name === "background" ? "background.js" : "content.js",
+        assetFileNames: "assets/[name][extname]",
+        chunkFileNames: "assets/[name].js"
       }
     }
   },


### PR DESCRIPTION
## Summary
- configure Vite's build to emit both the content script and background service worker bundles
- update the extension manifest so the background bundle only runs as the service worker

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfdc28e5048328adea248b9691016d