### PR TITLE
Forward automation routing fields through content bridge

### DIFF
--- a/src/content-bridge.ts
+++ b/src/content-bridge.ts
@@ -21,7 +21,25 @@
 
       if (!data || typeof data !== "object" || data.type !== requestType) return;
 
-      const { requestId, index, row, timeoutMs } = data;
+      const {
+        type: _ignoredType,
+        requestId,
+        index,
+        row,
+        timeoutMs,
+        receiverTabUrl,
+        autoCloseMs,
+        ...forwardExtras
+      } = data as {
+        type?: string;
+        requestId?: string;
+        index?: number;
+        row?: unknown;
+        timeoutMs?: number;
+        receiverTabUrl?: string;
+        autoCloseMs?: number;
+        [key: string]: unknown;
+      };
 
       if (!requestId || pendingRequests.has(requestId)) return;
 
@@ -39,7 +57,17 @@
 
       pendingRequests.set(requestId, { origin: event.origin, timerId });
 
-      chrome.runtime.sendMessage({ type: requestType, requestId, index, row }, (response) => {
+      const bridgeRequest = {
+        type: requestType,
+        requestId,
+        index,
+        row,
+        receiverTabUrl,
+        autoCloseMs,
+        ...forwardExtras,
+      };
+
+      chrome.runtime.sendMessage(bridgeRequest, (response) => {
         const lastError = chrome.runtime?.lastError;
         const requestEntry = pendingRequests.get(requestId);
         if (!requestEntry) return;


### PR DESCRIPTION
## Summary
- forward receiverTabUrl, autoCloseMs, and other routing fields from the content bridge to the background worker
- keep the timeout handling intact while allowing the bridge to forward any extra payload data transparently

## Testing
- npm run build
- node tmp/test-content-bridge.cjs

------
https://chatgpt.com/codex/tasks/task_e_68d0f13257248328a10ac568a4296d0c